### PR TITLE
[refactor] フーリエ変換処理の共通化

### DIFF
--- a/FFT.h
+++ b/FFT.h
@@ -32,131 +32,107 @@ T power(T const &x, long long N){
   return result;
 }
 
-template <class InputIterator, class OutputIterator>
-  void FFT(int n_sample, InputIterator  data_first,
-	   OutputIterator real_first, OutputIterator imag_first){
+template <class T>
+std::vector<std::complex<double>> FFT_impl(int n_sample, T create_input)
+{
   // ------ size investigation ------ //
-  assert( (n_sample & (n_sample - 1) ) == 0);
-  auto log2 = [](int N)
+  assert((n_sample & (n_sample - 1)) == 0);
+  auto log2 = [](int N) {
+    int count = 0;
+    while (N != 1)
     {
-     int count = 0;
-     while(N != 1){
-       N /= 2;
-       ++count;
-     }
-     return count;
-    };
-  
-  int n = log2(n_sample);
-  
+      N /= 2;
+      ++count;
+    }
+    return count;
+  };
+
+  const int log2_of_n_sample = log2(n_sample);
+
   // ------ Rotation factor ---- //
   const double pi = 3.14159265358979; // pi
-  std::vector<std::complex<double> > W(n_sample);
-  for(int i = 0; i < n_sample ; i++){
-    W[i] = Exp_i( - i * 2 * pi / n_sample);
+  std::vector<std::complex<double>> W(n_sample);
+  for (int i = 0; i < n_sample; i++)
+  {
+    W[i] = Exp_i(-i * 2 * pi / n_sample);
   }
-  
+
   // ---- Reserve array for output of butterfly operation ---- //
   std::array<std::vector<std::complex<double>>, 2> aft_btfly = {
-      std::vector<std::complex<double>>(n_sample),
+      create_input(n_sample, log2_of_n_sample),
       std::vector<std::complex<double>>(n_sample),
   }; // include input data itself at[0];
-  
-  // ---- Data as complex numbers -------//
-  // --> Input data to aft_btfly[0][i] 
-  for(int i = 0 ; i < n_sample ; i++){
-    int bit_inv_i = binary_inversion(i, n);
-    aft_btfly[0][i] = { static_cast<double>(*(data_first + bit_inv_i)), 0 };
-  }
-  
+
   // ------ FFT ------ //
-  for(int i = 1 ; i <= n ; i++){
-    int num_btfly  = power(2, i - 1);
-    int rot_factor = power(2, n - i);
-    int num_group  = rot_factor;
-    for(int j = 0 ; j < num_btfly ; ++j){
-      for(int k = 0 ; k < num_group ; ++k){
-	int top_index      = 2 * num_btfly * k + j;
-	int bottom_index   = 2 * num_btfly * k + j + num_btfly;
-	aft_btfly[1][top_index] = aft_btfly[0][top_index] + W[rot_factor * j] * aft_btfly[0][bottom_index];
-	aft_btfly[1][bottom_index] = aft_btfly[0][top_index] - W[rot_factor * j] * aft_btfly[0][bottom_index];
-      }// k
-    }// j
+  for (int i = 1; i <= log2_of_n_sample; i++)
+  {
+    int num_btfly = power(2, i - 1);
+    int rot_factor = power(2, log2_of_n_sample - i);
+    int num_group = rot_factor;
+    for (int j = 0; j < num_btfly; ++j)
+    {
+      for (int k = 0; k < num_group; ++k)
+      {
+        int top_index = 2 * num_btfly * k + j;
+        int bottom_index = 2 * num_btfly * k + j + num_btfly;
+        aft_btfly[1][top_index] = aft_btfly[0][top_index] + W[rot_factor * j] * aft_btfly[0][bottom_index];
+        aft_btfly[1][bottom_index] = aft_btfly[0][top_index] - W[rot_factor * j] * aft_btfly[0][bottom_index];
+      } // k
+    }   // j
     aft_btfly[0].swap(aft_btfly[1]);
-  }// i : 1 -> n
-  
+  } // i : 1 -> log2_of_n_sample
+
+  return aft_btfly[0];
+}
+
+template <class InputIterator, class OutputIterator>
+void FFT(int n_sample, InputIterator data_first,
+         OutputIterator real_first, OutputIterator imag_first)
+{
+  const auto result = FFT_impl(n_sample, [data_first](int n_sample, int log2_of_n_sanmple) {
+    std::vector<std::complex<double>> input(n_sample);
+    for (int i = 0; i < n_sample; i++)
+    {
+      int bit_inv_i = binary_inversion(i, log2_of_n_sanmple);
+      input[i] = {static_cast<double>(*(data_first + bit_inv_i)), 0};
+    }
+    return input;
+  });
+
   // ------ COPY ------ //
-  for (auto &&r : aft_btfly[0]){
+  for (auto &&r : result)
+  {
     *real_first = r.real();
     *imag_first = r.imag();
     ++real_first;
     ++imag_first;
   }
-  
+
   return;
 }
 
 template <class InputIterator, class OutputIterator>
 void InverseFFT(int n_sample, InputIterator in_first_Re, InputIterator in_first_Im,
 		OutputIterator out_first_Re, OutputIterator out_first_Im){
-  // ------ size investigation ------ //
-  assert( ( n_sample & (n_sample - 1) ) == 0);
-  auto log2 = [](int N)
-	      {
-		int count = 0;
-		while(N != 1){
-		  N /= 2;
-		  ++count;
-		}
-		return count;
-	      };
-  
-  int n = log2(n_sample);
-  
-  // ------ Rotation factor ---- //
-  const double pi = 3.14159265358979; // pi
-  std::vector<std::complex<double> > W(n_sample);
-  for(int i = 0; i < n_sample ; i++){
-    W[i] = Exp_i( - i * 2 * pi / n_sample);
-  }
-  
-  // ---- Reserve array for output of butterfly operation ---- //
-  std::array<std::vector<std::complex<double>>, 2> aft_btfly = {
-      std::vector<std::complex<double>>(n_sample),
-      std::vector<std::complex<double>>(n_sample),
-  }; 
-  
-  // ---- Data as complex numbers -------//
-  /////// Input data to aft_btfly[0][i] ///////
-  for(int i = 0 ; i < n_sample ; i++){
-    int bit_inv_i = binary_inversion(i, n);
-    aft_btfly[0][i] = { static_cast<double>(*(in_first_Re + bit_inv_i) ), static_cast<double>( *(in_first_Im + bit_inv_i) ) * (-1)};
-  }
-  
-  // ------ Inverse FFT ------ //
-  for(int i = 1 ; i <= n ; i++){
-    int num_btfly  = power(2, i - 1);
-    int rot_factor = power(2, n - i);
-    int num_group  = rot_factor;
-    for(int j = 0 ; j < num_btfly ; ++j){
-      for(int k = 0 ; k < num_group ; ++k){
- 	int top_index      = 2 * num_btfly * k + j;
-	int bottom_index   = 2 * num_btfly * k + j + num_btfly;
-	aft_btfly[1][top_index] = aft_btfly[0][top_index] + W[rot_factor * j] * aft_btfly[0][bottom_index];
-	aft_btfly[1][bottom_index] = aft_btfly[0][top_index] - W[rot_factor * j] * aft_btfly[0][bottom_index];
-      }// k
-    }// j
-    aft_btfly[0].swap(aft_btfly[1]);
-  }// i : 1 -> n
-  
+  const auto result = FFT_impl(n_sample, [in_first_Re, in_first_Im](int n_sample, int log2_of_n_sample) {
+    std::vector<std::complex<double>> input(n_sample);
+    for (int i = 0; i < n_sample; i++)
+    {
+      int bit_inv_i = binary_inversion(i, log2_of_n_sample);
+      input[i] = {static_cast<double>(*(in_first_Re + bit_inv_i)), static_cast<double>(*(in_first_Im + bit_inv_i)) * (-1)};
+    }
+    return input;
+  });
+
   // ------ COPY ------ //
-  for (auto &&r : aft_btfly[0]){
+  for (auto &&r : result)
+  {
     *out_first_Re = r.real() / n_sample;
     *out_first_Im = r.imag() / n_sample;
     ++out_first_Re;
     ++out_first_Im;
   }
-  
+
   return;
 }
 #endif


### PR DESCRIPTION
FFTとInvertFFTの処理はどちらも入出力の生成以外は全く同じなので、DRY(Don't Repeat Yourself)の原則に従い、処理を共通化しました。